### PR TITLE
fix(frontend): Properly display icon in OgImage

### DIFF
--- a/frontend/app/components/og-image/DefaultOgImage.vue
+++ b/frontend/app/components/og-image/DefaultOgImage.vue
@@ -61,7 +61,7 @@ const siteName = computed(() => props.siteName || useSiteConfig().name)
           </p>
         </div>
         <div v-if="icon" class="flex justify-end" style="width: 30%;">
-          <NuxtImg :src="icon" height="100" />
+          <img :src="icon" height="100" alt="Hack4Krak">
         </div>
       </div>
       <div class="flex flex-row justify-center items-center text-left w-full">


### PR DESCRIPTION
Resolves #102

I also properly had to configure `NUXT_SITE_URL` env.

Note: It may not work on this preview, because I didn't want to modify our codebase to respect Vercel's env variables, but on main branch it should work. You can view preview [here](https://hack4krak-hn1eyay6g-spacemceu.vercel.app/__og-image__/image/og.png).