### PR TITLE
Fix: Made auth middleware team requirements return 403 user is not a leader only when team requirement is set to leader

### DIFF
--- a/backend/src/middlewares/auth.rs
+++ b/backend/src/middlewares/auth.rs
@@ -169,7 +169,7 @@ impl<S> AuthMiddlewareService<S> {
                     }
                     .into());
                 };
-                if !user.is_leader {
+                if !user.is_leader && config.team_requirement == TeamRequirement::Leader {
                     return Err(TeamError::UserIsNotTeamLeader.into());
                 }
                 if config.insert_team_extension {


### PR DESCRIPTION
Resolves: #198 