### PR TITLE
fix: Add workflow permissions (code scanning alert no. 3)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
     branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DATABASE_URL: postgres://backend:password@localhost:5432/hack4krak
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Potential fix for [https://github.com/Hack4Krak/Hack4KrakSite/security/code-scanning/3](https://github.com/Hack4Krak/Hack4KrakSite/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for the workflow. Based on the actions performed in the workflow, such as checking out the repository and running tests, the `contents: read` permission is sufficient. This change ensures that the `GITHUB_TOKEN` has only the necessary permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
