### PR TITLE
fix(backend): sort flag captures by submitted date

### DIFF
--- a/backend/src/utils/points_counter.rs
+++ b/backend/src/utils/points_counter.rs
@@ -1,7 +1,7 @@
 use crate::entities::{flag_capture, teams};
 use crate::utils::error::Error;
 use chrono::NaiveDateTime;
-use sea_orm::{DatabaseConnection, EntityTrait};
+use sea_orm::{DatabaseConnection, EntityTrait, QueryOrder};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
@@ -44,7 +44,10 @@ pub struct PointsCounter {
 
 impl PointsCounter {
     pub async fn work(database: &DatabaseConnection) -> Result<PointsCounter, Error> {
-        let captures = flag_capture::Entity::find().all(database).await?;
+        let captures = flag_capture::Entity::find()
+            .order_by_asc(flag_capture::Column::SubmittedAt)
+            .all(database)
+            .await?;
         let teams = teams::Entity::find().all(database).await?;
 
         let mut output = Self::default();


### PR DESCRIPTION
Resolves #617 

PostgresSQL docs:

> "The rows returned by a SELECT query are unordered unless ORDER BY is used to impose a specific ordering."

> "Without ORDER BY, the database is free to return rows in any order."