### PR TITLE
chore(backend): Switch to `serde_norway` from `serde_yml`

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "sha2",
  "testcontainers",
  "thiserror 2.0.15",
@@ -1640,7 +1640,7 @@ name = "hack4krak-macros"
 version = "2.0.0"
 dependencies = [
  "quote",
- "serde_yml",
+ "serde_norway",
  "syn 2.0.106",
 ]
 
@@ -2296,16 +2296,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -3728,6 +3718,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.7.1",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3788,21 +3791,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap 2.7.1",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -4758,6 +4746,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 [workspace.dependencies]
 sea-orm = { version = "1.1.14", features = [ "sqlx-postgres", "sqlx-sqlite", "runtime-tokio-rustls", "macros", "mock" ] }
 tokio = { version = "1.47.1", features = ["macros", "rt", "rt-multi-thread", "fs"] }
-serde_yml = "0.0.12"
+serde_norway = "0.9.42"
 
 [dependencies]
 # Generating OpenAPI
@@ -39,7 +39,7 @@ actix-http = "3.11.1"
 # Serde
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
-serde_yml.workspace = true
+serde_norway.workspace = true
 
 # Workspace
 sea-orm.workspace = true

--- a/backend/macros/Cargo.toml
+++ b/backend/macros/Cargo.toml
@@ -10,4 +10,4 @@ proc-macro = true
 syn = { version = "^2.0.106", features = ["full"] }
 quote = "^1.0.40"
 
-serde_yml.workspace = true
+serde_norway.workspace = true

--- a/backend/macros/src/macros/localized_error.rs
+++ b/backend/macros/src/macros/localized_error.rs
@@ -8,7 +8,7 @@ pub fn localized_error_impl(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let enum_name = &input.ident;
 
-    let messages: serde_yml::Value = serde_yml::from_str(ERRORS_YAML).expect("Invalid YAML");
+    let messages: serde_norway::Value = serde_norway::from_str(ERRORS_YAML).expect("Invalid YAML");
 
     let enum_messages = messages
         .get(enum_name.to_string())

--- a/backend/src/services/task_manager.rs
+++ b/backend/src/services/task_manager.rs
@@ -57,7 +57,7 @@ impl TaskManager {
             let path = entry.path();
             let file_content = fs::read_to_string(path.join("config.yaml")).await.unwrap();
 
-            if let Ok(task) = serde_yml::from_str::<TaskConfig>(&file_content) {
+            if let Ok(task) = serde_norway::from_str::<TaskConfig>(&file_content) {
                 tasks.insert(task.meta.id.clone(), task);
             } else {
                 error!("Failed to parse task config at {:?}", path);
@@ -69,7 +69,7 @@ impl TaskManager {
         let path = EnvConfig::get().tasks_base_path.join(path);
 
         let file_content = fs::read_to_string(path).await.unwrap();
-        serde_yml::from_str::<T>(&file_content).unwrap()
+        serde_norway::from_str::<T>(&file_content).unwrap()
     }
 
     pub async fn load() -> Self {

--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -142,7 +142,7 @@ impl Email {
 
     fn meta(&self) -> EmailMeta {
         let file = include_str!("../../templates/email/config.yaml");
-        let templates: HashMap<String, EmailMeta> = serde_yml::from_str(file).unwrap();
+        let templates: HashMap<String, EmailMeta> = serde_norway::from_str(file).unwrap();
 
         match &self.meta {
             Some(meta) => meta.clone(),

--- a/backend/src/utils/error.rs
+++ b/backend/src/utils/error.rs
@@ -81,7 +81,7 @@ pub enum Error {
     #[serde(skip)]
     InvalidJson(#[from] serde_json::Error),
     #[serde(skip)]
-    InvalidYaml(#[from] serde_yml::Error),
+    InvalidYaml(#[from] serde_norway::Error),
     InvalidEmailConfirmationCode,
     InvalidColorFormat,
     EmailConfirmationCodeExpired,


### PR DESCRIPTION
Reason for this is `serde_yml` and its dependency `libyml` being archived and unmaintained as stated in security alerts no. 17 and 18.