### PR TITLE
refactor(frontend): Use isolated install when possible

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,2 @@
 [install]
-linker = "hoisted"
+publicHoistPattern = ["tailwind-variants", "@vueuse/core", "dayjs", "tailwindcss"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ FROM base as prerelease
 COPY package.json bun.lock ./
 COPY frontend/package.json frontend/
 COPY backend/package.json backend/
-COPY bunfig.toml .
+RUN echo -e "[install]\nlinker = \"hoisted\"" > bunfig.toml
 
 RUN bun install --frozen-lockfile --filter hack4krak-frontend
 


### PR DESCRIPTION
Switch for using mainly isolated install, with `tailwind-variants`, `@vueuse/core`, `dayjs` and `tailwindcss` hoisted. Hoisting those packages is required for typechecks and build to pass.
Unfortunately, production build with Docker still requires hoisting, because otherwise it literally cannot resolve any dependency while importing.

This is part of #713 