### PR TITLE
fix: use proper volume path for postgres docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: hack4krak_postgres
-    image: postgres:latest
+    image: postgres:18
     restart: on-failure
     shm_size: 128mb
     environment:
@@ -11,7 +11,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - database:/var/lib/postgresql/data
+      - database:/var/lib/postgresql
     profiles:
       - db
       - all


### PR DESCRIPTION
They changed default volume path for postgres 18, which resulted in errors while trying to start db from docker.