### PR TITLE
fix(frontend): fix copy button not working in code blocks

### DIFF
--- a/frontend/app/plugins/code-block-copy.client.ts
+++ b/frontend/app/plugins/code-block-copy.client.ts
@@ -19,7 +19,9 @@ export default defineNuxtPlugin(() => {
       navigator.clipboard.writeText(pre.textContent ?? '')
       clearTimeout(timer)
       btn.innerHTML = checkSvg
-      timer = window.setTimeout(() => { btn.innerHTML = originalHTML }, 2000)
+      timer = window.setTimeout(() => {
+        btn.innerHTML = originalHTML
+      }, 2000)
     })
   }
 


### PR DESCRIPTION
Fixes copy button in code blocks not working inside server components by attaching native click listeners via a client plugin with MutationObserver. Probably horror implementation

Closes #786