### PR TITLE
feat(frontend): add padding to tasks page

### DIFF
--- a/frontend/app/components/Map.vue
+++ b/frontend/app/components/Map.vue
@@ -109,7 +109,7 @@ onMounted(() => {
                   'hover:drop-shadow-[0px_0px_2px_#555555]': !completedTasks.includes(item.id),
                   'drop-shadow-[0px_0px_2px_#458018]': completedTasks.includes(item.id),
                 }"
-                class="rendering-pixelated hover:drop-shadow-[0px_0px_2px_#555555] transition-all duration-300 ease-in-out"
+                class="rendering-pixelated hover:drop-shadow-[0px_0px_2px_#555555] transition-all duration-300 ease-in-out select-none"
                 :alt="item.name"
               >
             </NuxtLink>


### PR DESCRIPTION
Closes #546

I also added `select-none` to prevent this from happening:
<img width="446" height="319" alt="image" src="https://github.com/user-attachments/assets/50f70de5-df92-4ca2-a11e-caba903d018b" />

Before:
<img width="1920" height="965" alt="image" src="https://github.com/user-attachments/assets/d541cf05-daa9-46e7-abb3-1604e6a528d5" />

After:
<img width="1920" height="965" alt="image" src="https://github.com/user-attachments/assets/83bf7860-9068-4715-8085-7469c40d1de0" />
