### PR TITLE
feat(frontend): add TV display page

### DIFF
--- a/frontend/app/components/leaderboard/Chart.vue
+++ b/frontend/app/components/leaderboard/Chart.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import type { EChartsOption } from 'echarts'
-import dayjs from 'dayjs'
-import timezone from 'dayjs/plugin/timezone'
-import utc from 'dayjs/plugin/utc'
 import * as echarts from 'echarts/core'
 import { SVGRenderer } from 'echarts/renderers'
 
@@ -10,119 +6,16 @@ echarts.use([SVGRenderer])
 
 const initOptions = { renderer: 'svg' } as const
 
-dayjs.extend(utc)
-dayjs.extend(timezone)
-
-interface TeamData {
-  name: string
-  points: number[]
-  color: string
-}
-
-const targetTimezone = 'Europe/Warsaw'
-
 const { data: chartData } = useLazyApi('/leaderboard/chart')
 const { data: eventInformation } = useLazyApi('/event/info')
 
-const adjustedTimestamps = computed(() =>
-  chartData.value?.event_timestamps?.map((ts: string) =>
-    dayjs.utc(ts).tz(targetTimezone).format('YYYY-MM-DDTHH:mm:ss'),
-  ) ?? [],
-)
+const startDate = computed(() => eventInformation.value?.start_date)
+const endDate = computed(() => eventInformation.value?.end_date)
 
-const chartOption = computed<EChartsOption>(() => {
-  if (!chartData.value?.team_points_over_time?.length || !eventInformation.value) {
-    return { series: [] }
-  }
-
-  const { start_date, end_date } = eventInformation.value
-  const start = start_date ? new Date(start_date) : undefined
-  const end = end_date ? new Date(end_date) : undefined
-
-  return {
-    tooltip: {
-      trigger: 'axis',
-      order: 'valueDesc',
-      confine: true,
-      appendToBody: true,
-      backgroundColor: '#000000',
-      borderWidth: 0,
-      textStyle: { color: '#ffffff' },
-      transitionDuration: 1,
-      renderMode: 'html',
-
-      axisPointer: {
-        type: 'line',
-        label: {
-          formatter: (params: any) => {
-            return dayjs(params.value).format('DD.MM.YYYY HH:mm')
-          },
-        },
-      },
-    },
-
-    legend: {
-      type: 'scroll',
-      bottom: 10,
-      textStyle: { color: '#e5e5e5', fontSize: 12 },
-      inactiveColor: '#525252',
-      animation: true,
-      animationDurationUpdate: 300,
-    },
-
-    grid: {
-      left: '3%',
-      right: '4%',
-      bottom: '15%',
-    },
-
-    xAxis: {
-      type: 'time',
-      min: start,
-      max: end,
-      name: 'Date',
-      nameLocation: 'middle',
-      nameGap: 35,
-      axisLabel: {
-        formatter: '{dd}.{MM}.{yyyy} {HH}:{mm}',
-      },
-    },
-
-    yAxis: {
-      type: 'value',
-      name: 'Liczba punktów',
-      nameLocation: 'middle',
-      nameGap: 50,
-      splitLine: {
-        lineStyle: { color: '#737373', width: 1, type: 'solid' },
-      },
-    },
-
-    series: chartData.value.team_points_over_time.map((item: TeamData) => ({
-      name: item.name,
-      type: 'line',
-      smooth: true,
-      symbol: 'circle',
-      symbolSize: 6,
-      animation: false,
-      data: item.points.map((point: number, i: number) => [
-        adjustedTimestamps.value[i],
-        point,
-      ]),
-      lineStyle: {
-        color: item.color,
-        width: 2,
-        opacity: 0.8,
-      },
-      itemStyle: {
-        color: item.color,
-        borderWidth: 0,
-      },
-      emphasis: {
-        disabled: true,
-      },
-    })),
-  }
+const { chartOption } = useLeaderboardChart({
+  chartData,
+  startDate,
+  endDate,
 })
 </script>
 

--- a/frontend/app/components/tv/Leaderboard.vue
+++ b/frontend/app/components/tv/Leaderboard.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import type { TvTask, TvTeam } from '~/composables/useTvData'
+import dayjs from 'dayjs'
+
+const props = defineProps<{
+  teams: TvTeam[]
+  tasks: TvTask[]
+}>()
+
+const scrollContainer = ref<HTMLElement | null>(null)
+useAutoScroll(scrollContainer, { speed: 1, pauseMs: 3000 })
+
+const podiumConfig = [
+  { height: 'h-28', barColor: 'bg-gray-400', glowColor: 'shadow-[0_0_20px_rgba(156,163,175,0.3)]', label: '2', iconColor: 'text-gray-300', icon: 'lucide:medal', isFirst: false },
+  { height: 'h-36', barColor: 'bg-yellow-400', glowColor: 'shadow-[0_0_30px_rgba(250,204,21,0.4)]', label: '1', iconColor: 'text-yellow-400', icon: 'pixelarticons:trophy', isFirst: true },
+  { height: 'h-22', barColor: 'bg-amber-600', glowColor: 'shadow-[0_0_15px_rgba(217,119,6,0.25)]', label: '3', iconColor: 'text-amber-600', icon: 'lucide:medal', isFirst: false },
+]
+
+const podiumEntries = computed(() => {
+  if (props.teams.length < 3)
+    return []
+  const ordered = [props.teams[1], props.teams[0], props.teams[2]]
+  return ordered.map((team, i) => ({
+    team: team!,
+    config: podiumConfig[i]!,
+  }))
+})
+
+const restTeams = computed(() => props.teams.slice(3))
+
+function getTasksSolved(team: TvTeam) {
+  if (!team.tasks)
+    return 0
+  return Object.keys(team.tasks).length
+}
+
+function getLastSolveTime(team: TvTeam) {
+  if (!team.tasks)
+    return null
+  const times = Object.values(team.tasks)
+  if (!times.length)
+    return null
+  const sorted = [...times].sort((a, b) => new Date(b).getTime() - new Date(a).getTime())
+  return dayjs(sorted[0]).format('HH:mm')
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex items-center gap-3 px-4 py-3 border-b border-surface-muted">
+      <UIcon name="pixelarticons:trophy" class="text-xl text-primary" />
+      <h2 class="text-lg font-bold text-text-default uppercase tracking-wider">
+        Ranking
+      </h2>
+    </div>
+
+    <div v-if="podiumEntries.length === 3" class="px-4 pt-5 pb-2">
+      <div class="flex items-end justify-center gap-3">
+        <div
+          v-for="entry in podiumEntries"
+          :key="entry.team.team_id"
+          class="flex-1 flex flex-col items-center"
+        >
+          <div class="flex flex-col items-center gap-1.5 mb-3">
+            <UIcon
+              :name="entry.config.icon"
+              :class="[entry.config.iconColor, entry.config.isFirst ? 'text-4xl podium-bounce' : 'text-2xl']"
+            />
+            <span
+              class="font-bold text-center truncate max-w-full px-1" :class="[
+                entry.config.isFirst ? 'text-base text-yellow-400' : 'text-sm text-text-default',
+              ]"
+            >
+              {{ entry.team.team_name }}
+            </span>
+            <span
+              class="font-bold tabular-nums font-pixelify" :class="[
+                entry.config.isFirst ? 'text-3xl text-yellow-400 podium-glow-text' : 'text-xl text-primary',
+              ]"
+            >
+              {{ entry.team.current_points ?? 0 }}
+            </span>
+            <span class="text-xs text-text-muted tabular-nums">
+              {{ getTasksSolved(entry.team) }}/{{ tasks.length }} flag
+            </span>
+          </div>
+
+          <div
+            class="w-full flex items-center justify-center transition-all duration-700" :class="[
+              entry.config.height,
+              entry.config.barColor,
+              entry.config.glowColor,
+            ]"
+          >
+            <span class="text-4xl font-bold font-pixelify text-surface-default/80">
+              {{ entry.config.label }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else-if="teams.length > 0 && teams.length < 3" class="px-4 pt-4">
+      <div
+        v-for="(team, index) in teams"
+        :key="team.team_id"
+        class="flex items-center gap-3 py-2 px-3 mb-1 border border-surface-muted"
+      >
+        <span class="text-lg font-bold tabular-nums text-primary w-8 text-center">{{ index + 1 }}</span>
+        <div class="w-3 h-3 shrink-0" :style="{ backgroundColor: team.color || '#737373' }" />
+        <span class="font-semibold text-text-default flex-1 truncate">{{ team.team_name }}</span>
+        <span class="font-bold text-primary tabular-nums">{{ team.current_points ?? 0 }} pkt</span>
+      </div>
+    </div>
+
+    <div ref="scrollContainer" class="flex-1 overflow-hidden border-t border-surface-muted mt-2">
+      <table v-if="restTeams.length" class="w-full">
+        <tbody>
+          <tr
+            v-for="(team, index) in restTeams"
+            :key="team.team_id"
+            class="border-b border-surface-muted/50 transition-all duration-500 hover:bg-surface-muted/30"
+          >
+            <td class="py-2 px-4 text-center w-10">
+              <span class="text-text-muted text-sm tabular-nums">{{ index + 4 }}</span>
+            </td>
+            <td class="py-2 px-4">
+              <div class="flex items-center gap-2">
+                <div class="w-2.5 h-2.5 shrink-0" :style="{ backgroundColor: team.color || '#737373' }" />
+                <span class="text-text-default truncate text-sm">{{ team.team_name }}</span>
+              </div>
+            </td>
+            <td class="py-2 px-4 text-center w-20">
+              <span class="font-bold text-primary tabular-nums">{{ team.current_points ?? 0 }}</span>
+            </td>
+            <td class="py-2 px-4 text-center w-16">
+              <span class="text-text-muted tabular-nums text-xs">
+                {{ getTasksSolved(team) }}/{{ tasks.length }}
+              </span>
+            </td>
+            <td class="py-2 px-4 text-center w-16">
+              <span class="text-text-muted text-xs tabular-nums">
+                {{ getLastSolveTime(team) ?? '—' }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div v-if="!teams.length" class="flex items-center justify-center h-full text-text-muted">
+        Brak danych
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/app/components/tv/NotificationToast.vue
+++ b/frontend/app/components/tv/NotificationToast.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+const props = defineProps<{
+  type: 'first-solve' | 'all-solved'
+  taskName: string
+  teamName?: string
+  teamColor?: string
+}>()
+
+const emit = defineEmits<{
+  dismiss: []
+}>()
+
+const visible = ref(false)
+
+onMounted(() => {
+  requestAnimationFrame(() => {
+    visible.value = true
+  })
+  setTimeout(() => {
+    visible.value = false
+    setTimeout(emit, 500, 'dismiss')
+  }, 5000)
+})
+
+const isAllSolved = computed(() => props.type === 'all-solved')
+</script>
+
+<template>
+  <Transition name="tv-toast">
+    <div
+      v-if="visible"
+      class="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 max-w-2xl w-full px-4"
+    >
+      <div
+        class="flex items-center gap-5 px-8 py-5 border-2" :class="[
+          isAllSolved
+            ? 'bg-surface-default border-primary'
+            : 'bg-surface-default border-surface-muted',
+        ]"
+      >
+        <div
+          class="shrink-0 w-14 h-14 flex items-center justify-center border-2" :class="[
+            isAllSolved ? 'border-primary' : 'border-surface-muted',
+          ]"
+        >
+          <UIcon
+            :name="isAllSolved ? 'pixelarticons:trophy' : 'pixelarticons:flag'"
+            class="text-3xl" :class="[
+              isAllSolved ? 'text-primary' : 'text-green-500',
+            ]"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1 min-w-0">
+          <span class="text-xs uppercase tracking-widest text-text-muted">
+            {{ isAllSolved ? 'Wszystkie drużyny ukończyły' : 'Nowe rozwiązanie' }}
+          </span>
+          <span class="text-xl font-bold text-text-default truncate">
+            {{ taskName }}
+          </span>
+          <div v-if="teamName && !isAllSolved" class="flex items-center gap-2">
+            <div
+              class="w-2.5 h-2.5 shrink-0"
+              :style="{ backgroundColor: teamColor || '#737373' }"
+            />
+            <span class="text-sm text-text-muted">
+              {{ teamName }}
+            </span>
+          </div>
+        </div>
+
+        <div v-if="isAllSolved" class="ml-auto shrink-0">
+          <UIcon name="pixelarticons:check-double" class="text-4xl text-primary" />
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.tv-toast-enter-active,
+.tv-toast-leave-active {
+  transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.tv-toast-enter-from,
+.tv-toast-leave-to {
+  opacity: 0;
+  transform: translate(-50%, 100%);
+}
+</style>

--- a/frontend/app/components/tv/ScoreChart.vue
+++ b/frontend/app/components/tv/ScoreChart.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { ApiResponse } from '#open-fetch'
+import * as echarts from 'echarts/core'
+import { SVGRenderer } from 'echarts/renderers'
+
+const props = defineProps<{
+  chartData: ApiResponse<'chart'> | null
+  startDate?: string
+  endDate?: string
+}>()
+
+echarts.use([SVGRenderer])
+
+const initOptions = { renderer: 'svg' } as const
+
+const chartDataRef = computed(() => props.chartData)
+const startDateRef = computed(() => props.startDate)
+const endDateRef = computed(() => props.endDate)
+
+const { chartOption } = useLeaderboardChart({
+  chartData: chartDataRef,
+  startDate: startDateRef,
+  endDate: endDateRef,
+  compact: true,
+})
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex items-center gap-3 px-4 py-3 border-b border-surface-muted">
+      <UIcon name="pixelarticons:chart" class="text-xl text-primary" />
+      <h2 class="text-lg font-bold text-text-default uppercase tracking-wider">
+        Postęp punktowy
+      </h2>
+    </div>
+
+    <div class="flex-1 min-h-0 p-2">
+      <VChart
+        v-if="chartData?.team_points_over_time?.length"
+        :option="chartOption"
+        autoresize
+        :init-options="initOptions"
+        class="h-full w-full"
+      />
+      <div v-else class="h-full flex items-center justify-center text-text-muted">
+        Oczekiwanie na dane...
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/app/components/tv/TaskProgress.vue
+++ b/frontend/app/components/tv/TaskProgress.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import type { TvTask, TvTeam } from '~/composables/useTvData'
+
+const props = defineProps<{
+  teams: TvTeam[]
+  tasks: TvTask[]
+}>()
+
+const scrollContainer = ref<HTMLElement | null>(null)
+useAutoScroll(scrollContainer, { speed: 1, pauseMs: 3000 })
+
+const taskProgress = computed(() => {
+  const totalTeams = props.teams.length
+  if (!totalTeams)
+    return []
+
+  return props.tasks.map((task) => {
+    const solvers = props.teams.filter(t => t.tasks?.[task.id]).length
+    return {
+      id: task.id,
+      name: task.name,
+      solved: solvers,
+      total: totalTeams,
+      percent: Math.round((solvers / totalTeams) * 100),
+    }
+  }).sort((a, b) => b.percent - a.percent)
+})
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex items-center gap-3 px-4 py-3 border-b border-surface-muted">
+      <UIcon name="pixelarticons:flag" class="text-xl text-primary" />
+      <h2 class="text-lg font-bold text-text-default uppercase tracking-wider">
+        Zadania
+      </h2>
+    </div>
+
+    <div ref="scrollContainer" class="flex-1 overflow-y-auto px-4 py-3 space-y-2.5">
+      <div
+        v-for="task in taskProgress"
+        :key="task.id"
+        class="flex items-center gap-3"
+      >
+        <span class="text-xs text-text-default truncate w-28 shrink-0 text-right">
+          {{ task.name }}
+        </span>
+        <div class="flex-1 h-4 bg-surface-muted relative overflow-hidden">
+          <div
+            class="h-full transition-all duration-700 ease-out"
+            :class="task.percent === 100 ? 'bg-primary' : 'bg-primary/60'"
+            :style="{ width: `${task.percent}%` }"
+          />
+        </div>
+        <span class="text-xs tabular-nums text-text-muted w-14 shrink-0">
+          {{ task.solved }}/{{ task.total }}
+        </span>
+      </div>
+      <div v-if="!taskProgress.length" class="text-center text-text-muted py-4">
+        Brak danych
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/app/components/tv/TopBar.vue
+++ b/frontend/app/components/tv/TopBar.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import dayjs from 'dayjs'
+
+const props = defineProps<{
+  startDate?: string
+  endDate?: string
+  lunchStart?: string
+  lunchEnd?: string
+}>()
+
+const now = ref(new Date())
+useIntervalFn(() => {
+  now.value = new Date()
+}, 1000)
+
+const isLunchTime = computed(() => {
+  if (!props.lunchStart || !props.lunchEnd)
+    return false
+  const current = dayjs(now.value)
+  const startParts = props.lunchStart.split(':').map(Number)
+  const endParts = props.lunchEnd.split(':').map(Number)
+
+  const lunchStartTime = current.hour(startParts[0] ?? 0).minute(startParts[1] ?? 0).second(0)
+  const lunchEndTime = current.hour(endParts[0] ?? 0).minute(endParts[1] ?? 0).second(0)
+
+  return current.isAfter(lunchStartTime) && current.isBefore(lunchEndTime)
+})
+
+const timeLeft = computed(() => {
+  if (!props.endDate)
+    return null
+  const diff = Math.max(0, new Date(props.endDate).getTime() - now.value.getTime())
+  return {
+    hours: Math.floor(diff / (1000 * 60 * 60)),
+    minutes: Math.floor(diff / (1000 * 60)) % 60,
+    seconds: Math.floor(diff / 1000) % 60,
+    total: diff,
+  }
+})
+
+const currentTimeFormatted = computed(() =>
+  dayjs(now.value).format('HH:mm:ss'),
+)
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+</script>
+
+<template>
+  <div class="flex items-center justify-between px-8 py-3 bg-surface-muted border-b border-surface-muted">
+    <div class="flex items-center gap-3">
+      <UIcon name="pixelarticons:calendar" class="text-2xl text-primary" />
+      <span class="font-pixelify text-2xl text-primary tracking-wider">Hack4Krak</span>
+    </div>
+
+    <div class="flex items-center gap-6">
+      <template v-if="isLunchTime">
+        <div class="flex items-center gap-3 bg-primary/15 px-6 py-2 border border-primary/40">
+          <UIcon name="pixelarticons:coin" class="text-3xl text-primary animate-pulse" />
+          <span class="text-2xl font-bold text-primary font-pixelify tracking-wide">PORA OBIADOWA</span>
+          <UIcon name="pixelarticons:coin" class="text-3xl text-primary animate-pulse" />
+        </div>
+      </template>
+      <template v-else>
+        <div v-if="timeLeft && timeLeft.total > 0" class="flex items-center gap-3">
+          <UIcon name="pixelarticons:clock" class="text-2xl text-text-muted" />
+          <span class="text-sm text-text-muted uppercase tracking-wider">Do końca</span>
+          <span class="text-2xl font-bold font-roboto tabular-nums text-text-default">
+            {{ pad(timeLeft.hours) }}:{{ pad(timeLeft.minutes) }}:{{ pad(timeLeft.seconds) }}
+          </span>
+        </div>
+        <div v-else-if="timeLeft && timeLeft.total === 0" class="flex items-center gap-3">
+          <span class="text-2xl font-bold text-red-450 font-pixelify">KONIEC WYDARZENIA</span>
+        </div>
+      </template>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <UIcon name="pixelarticons:clock" class="text-2xl text-text-muted" />
+      <span class="text-3xl font-bold font-roboto tabular-nums text-text-default">
+        {{ currentTimeFormatted }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/frontend/app/composables/useAutoScroll.ts
+++ b/frontend/app/composables/useAutoScroll.ts
@@ -1,0 +1,45 @@
+import { useIntervalFn } from '@vueuse/core'
+
+export function useAutoScroll(containerRef: Ref<HTMLElement | null>, options: {
+  speed?: number
+  pauseMs?: number
+} = {}) {
+  const speed = options.speed ?? 1
+  const pauseMs = options.pauseMs ?? 2000
+
+  let direction: 'down' | 'up' = 'down'
+  let pauseUntil = 0
+
+  const { pause, resume } = useIntervalFn(() => {
+    const el = containerRef.value
+    if (!el)
+      return
+
+    const maxScroll = el.scrollHeight - el.clientHeight
+    if (maxScroll <= 0)
+      return
+
+    const now = Date.now()
+    if (now < pauseUntil)
+      return
+
+    if (direction === 'down') {
+      el.scrollTop += speed
+      if (el.scrollTop >= maxScroll) {
+        el.scrollTop = maxScroll
+        direction = 'up'
+        pauseUntil = now + pauseMs
+      }
+    }
+    else {
+      el.scrollTop -= speed
+      if (el.scrollTop <= 0) {
+        el.scrollTop = 0
+        direction = 'down'
+        pauseUntil = now + pauseMs
+      }
+    }
+  }, 30)
+
+  return { pause, resume }
+}

--- a/frontend/app/composables/useLeaderboardChart.ts
+++ b/frontend/app/composables/useLeaderboardChart.ts
@@ -1,0 +1,125 @@
+import type { ApiResponse } from '#open-fetch'
+import type { EChartsOption } from 'echarts'
+import dayjs from 'dayjs'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+const targetTimezone = 'Europe/Warsaw'
+
+interface TeamData {
+  name: string
+  points: number[]
+  color: string
+}
+
+interface ChartOptions {
+  chartData: Ref<ApiResponse<'chart'> | null | undefined>
+  startDate: Ref<string | undefined>
+  endDate: Ref<string | undefined>
+  compact?: boolean
+}
+
+export function useLeaderboardChart({ chartData, startDate, endDate, compact = false }: ChartOptions) {
+  const adjustedTimestamps = computed(() =>
+    chartData.value?.event_timestamps?.map((ts: string) =>
+      dayjs.utc(ts).tz(targetTimezone).format('YYYY-MM-DDTHH:mm:ss'),
+    ) ?? [],
+  )
+
+  const chartOption = computed<EChartsOption>(() => {
+    if (!chartData.value?.team_points_over_time?.length) {
+      return { series: [] }
+    }
+
+    const start = startDate.value ? new Date(startDate.value) : undefined
+    const end = endDate.value ? new Date(endDate.value) : undefined
+
+    return {
+      tooltip: {
+        trigger: 'axis',
+        order: 'valueDesc',
+        confine: true,
+        backgroundColor: '#171717',
+        borderColor: '#262626',
+        borderWidth: 1,
+        textStyle: { color: '#fafafa', fontSize: compact ? 14 : 12 },
+        transitionDuration: 0.3,
+        axisPointer: {
+          type: 'line',
+          lineStyle: { color: '#737373' },
+          label: {
+            formatter: (params: any) =>
+              dayjs(params.value).format(compact ? 'HH:mm' : 'DD.MM.YYYY HH:mm'),
+          },
+        },
+      },
+
+      legend: {
+        type: 'scroll',
+        bottom: compact ? 8 : 10,
+        textStyle: { color: '#e5e5e5', fontSize: compact ? 13 : 12 },
+        inactiveColor: '#525252',
+      },
+
+      grid: compact
+        ? { left: 60, right: 20, top: 20, bottom: 60 }
+        : { left: '3%', right: '4%', bottom: '15%' },
+
+      xAxis: {
+        type: 'time',
+        min: start,
+        max: end,
+        ...(compact
+          ? {}
+          : { name: 'Czas', nameLocation: 'middle', nameGap: 35, nameTextStyle: { color: '#e5e5e5', fontSize: 12 } }),
+        axisLabel: {
+          formatter: compact ? '{HH}:{mm}' : '{dd}.{MM}.{yyyy} {HH}:{mm}',
+          color: '#737373',
+          fontSize: 12,
+        },
+        axisLine: { lineStyle: { color: '#262626' } },
+        splitLine: { show: false },
+      },
+
+      yAxis: {
+        type: 'value',
+        name: compact ? 'Punkty' : 'Liczba punktów',
+        nameTextStyle: { color: compact ? '#737373' : '#e5e5e5', fontSize: 12 },
+        axisLabel: { color: '#737373', fontSize: 12 },
+        ...(compact ? {} : { nameLocation: 'middle', nameGap: 50 }),
+        splitLine: {
+          lineStyle: { color: compact ? '#262626' : '#737373', width: 1, type: 'solid' },
+        },
+      },
+
+      series: chartData.value.team_points_over_time.map((item: TeamData) => ({
+        name: item.name,
+        type: 'line',
+        smooth: true,
+        symbol: 'circle',
+        symbolSize: compact ? 4 : 6,
+        animation: compact,
+        ...(compact ? { animationDuration: 500 } : {}),
+        data: item.points.map((point: number, i: number) => [
+          adjustedTimestamps.value[i],
+          point,
+        ]),
+        lineStyle: {
+          color: item.color,
+          width: compact ? 2.5 : 2,
+          ...(compact ? {} : { opacity: 0.8 }),
+        },
+        itemStyle: {
+          color: item.color,
+          borderWidth: 0,
+        },
+        emphasis: { disabled: true },
+      })),
+    }
+  })
+
+  return { chartOption }
+}

--- a/frontend/app/composables/useTvData.ts
+++ b/frontend/app/composables/useTvData.ts
@@ -1,0 +1,110 @@
+import type { ApiResponse } from '#open-fetch'
+
+export type TvTeam = ApiResponse<'teams_with_tasks'>[0]
+export type TvTask = ApiResponse<'task_list'>[0]
+
+interface TaskEvent {
+  type: 'first-solve' | 'all-solved'
+  taskName: string
+  teamName?: string
+  teamColor?: string
+}
+
+export function useTvData(refreshInterval = 10000) {
+  const { $api } = useNuxtApp()
+
+  const teams = ref<TvTeam[]>([])
+  const tasks = ref<TvTask[]>([])
+  const chartData = ref<ApiResponse<'chart'> | null>(null)
+  const eventInfo = ref<ApiResponse<'info'> | null>(null)
+
+  const previousSolves = ref<Record<string, Set<string>>>({})
+  const taskEvents = ref<TaskEvent[]>([])
+
+  async function fetchAll() {
+    const [teamsRes, tasksRes, chartRes, eventRes] = await Promise.all([
+      $api('/leaderboard/teams_with_tasks'),
+      $api('/tasks/list'),
+      $api('/leaderboard/chart'),
+      $api('/event/info'),
+    ])
+
+    if (tasksRes)
+      tasks.value = tasksRes
+    if (chartRes)
+      chartData.value = chartRes
+    if (eventRes)
+      eventInfo.value = eventRes
+
+    if (teamsRes) {
+      detectNewSolves(teamsRes)
+      teams.value = teamsRes
+    }
+  }
+
+  function detectNewSolves(newTeams: TvTeam[]) {
+    if (!tasks.value.length)
+      return
+
+    const totalTeams = newTeams.length
+    const newEvents: TaskEvent[] = []
+
+    for (const task of tasks.value) {
+      const prevSolvers = previousSolves.value[task.id] ?? new Set()
+      const currentSolvers = new Set<string>()
+
+      for (const team of newTeams) {
+        if (team.tasks?.[task.id]) {
+          currentSolvers.add(team.team_id)
+
+          if (!prevSolvers.has(team.team_id)) {
+            newEvents.push({
+              type: 'first-solve',
+              taskName: task.name,
+              teamName: team.team_name,
+              teamColor: team.color,
+            })
+          }
+        }
+      }
+
+      if (currentSolvers.size === totalTeams && prevSolvers.size < totalTeams && totalTeams > 0) {
+        newEvents.push({
+          type: 'all-solved',
+          taskName: task.name,
+        })
+      }
+
+      previousSolves.value[task.id] = currentSolvers
+    }
+
+    if (newEvents.length > 0) {
+      taskEvents.value = [...taskEvents.value, ...newEvents]
+    }
+  }
+
+  function dismissEvent() {
+    taskEvents.value = taskEvents.value.slice(1)
+  }
+
+  const currentEvent = computed<TaskEvent | undefined>(() => taskEvents.value[0])
+
+  const sortedTeams = computed(() =>
+    [...teams.value].sort((a, b) => b.current_points - a.current_points),
+  )
+
+  fetchAll()
+  const { pause, resume } = useIntervalFn(fetchAll, refreshInterval)
+
+  return {
+    teams: sortedTeams,
+    tasks,
+    chartData,
+    eventInfo,
+    currentEvent,
+    dismissEvent,
+    pause,
+    resume,
+    refresh: fetchAll,
+  }
+}

--- a/frontend/app/composables/useTvSound.ts
+++ b/frontend/app/composables/useTvSound.ts
@@ -1,0 +1,41 @@
+export function useTvSound() {
+  let audioCtx: AudioContext | null = null
+
+  function getContext() {
+    if (!audioCtx) {
+      audioCtx = new AudioContext()
+    }
+    return audioCtx
+  }
+
+  function playTone(frequency: number, duration: number, type: OscillatorType = 'square') {
+    const ctx = getContext()
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+
+    osc.type = type
+    osc.frequency.setValueAtTime(frequency, ctx.currentTime)
+    gain.gain.setValueAtTime(0.15, ctx.currentTime)
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration)
+
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    osc.start()
+    osc.stop(ctx.currentTime + duration)
+  }
+
+  function playFirstSolve() {
+    playTone(440, 0.15)
+    setTimeout(playTone, 100, 554, 0.15)
+    setTimeout(playTone, 200, 659, 0.3)
+  }
+
+  function playAllSolved() {
+    playTone(523, 0.2, 'square')
+    setTimeout(playTone, 150, 659, 0.2, 'square')
+    setTimeout(playTone, 300, 784, 0.2, 'square')
+    setTimeout(playTone, 450, 1047, 0.5, 'square')
+  }
+
+  return { playFirstSolve, playAllSolved }
+}

--- a/frontend/app/pages/tv.vue
+++ b/frontend/app/pages/tv.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'no-navbar',
+})
+
+useSeoMeta({
+  title: 'TV – Ranking na żywo',
+  robots: 'noindex',
+})
+
+const LUNCH_START = '8:10'
+const LUNCH_END = '22:30'
+
+const { teams, tasks, chartData, eventInfo, currentEvent, dismissEvent } = useTvData(10000)
+const { playFirstSolve, playAllSolved } = useTvSound()
+
+watch(currentEvent, (event) => {
+  if (!event)
+    return
+  if (event.type === 'first-solve')
+    playFirstSolve()
+  else if (event.type === 'all-solved')
+    playAllSolved()
+})
+</script>
+
+<template>
+  <div class="h-screen w-screen bg-surface-default flex flex-col overflow-hidden">
+    <TvTopBar
+      :start-date="eventInfo?.start_date"
+      :end-date="eventInfo?.end_date"
+      :lunch-start="LUNCH_START"
+      :lunch-end="LUNCH_END"
+    />
+
+    <div class="flex-1 flex min-h-0">
+      <div class="w-[45%] border-r border-surface-muted flex flex-col">
+        <div class="flex-1 min-h-0">
+          <TvLeaderboard :teams="teams" :tasks="tasks" />
+        </div>
+      </div>
+
+      <div class="w-[55%] flex flex-col">
+        <div class="flex-[3] min-h-0 border-b border-surface-muted">
+          <TvScoreChart
+            :chart-data="chartData"
+            :start-date="eventInfo?.start_date"
+            :end-date="eventInfo?.end_date"
+          />
+        </div>
+        <div class="flex-[2] min-h-0">
+          <TvTaskProgress :teams="teams" :tasks="tasks" />
+        </div>
+      </div>
+    </div>
+
+    <TvNotificationToast
+      v-if="currentEvent"
+      :key="`${currentEvent.type}-${currentEvent.taskName}-${currentEvent.teamName}`"
+      :type="currentEvent.type"
+      :task-name="currentEvent.taskName"
+      :team-name="currentEvent.teamName"
+      :team-color="currentEvent.teamColor"
+      @dismiss="dismissEvent"
+    />
+  </div>
+</template>


### PR DESCRIPTION
I also added a `useLeaderboardChart` composable to keep chart config consistent between the TV and regular leaderboard pages

Feedback is welcome

Preview:
https://github.com/user-attachments/assets/fb3d260e-8f3a-402f-bd46-f8f06307bb50

