### PR TITLE
feat(frontend): add username & context menu to navigation

### DIFF
--- a/frontend/app/components/Navbar.vue
+++ b/frontend/app/components/Navbar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { NAVBAR_ITEMS } from '~~/content/navbar'
 
-const { data: isLoggedIn } = useAuth('/auth/status', {
+const { data: user } = useAuth('/account/', {
   redirect: 'error',
   onResponseError: undefined,
 })
@@ -18,6 +18,35 @@ const navigationMenuProperties = computed(() => ({
     list: 'gap-8',
   },
 }))
+
+const userMenuItems = computed(() => [
+  [
+    {
+      label: user.value?.username ?? 'Użytkownik',
+      type: 'label' as const,
+    },
+  ],
+  [
+    {
+      label: 'Panel',
+      icon: 'pixelarticons:dashboard',
+      onSelect: () => navigateTo('/panel'),
+    },
+    {
+      label: 'Profil',
+      icon: 'pixelarticons:user',
+      onSelect: () => navigateTo('/panel/profile'),
+    },
+  ],
+  [
+    {
+      label: 'Wyloguj się',
+      icon: 'pixelarticons:logout',
+      color: 'error' as const,
+      onSelect: () => useSession().logout(),
+    },
+  ],
+])
 </script>
 
 <template>
@@ -29,12 +58,30 @@ const navigationMenuProperties = computed(() => ({
     <UNavigationMenu v-bind="navigationMenuProperties" />
 
     <template #right>
-      <NuxtLink to="/login" class="text-md font-semibold flex grow-0" :aria-label="isLoggedIn ? 'Otwórz panel' : 'Zaloguj się'">
-        <UIcon :name="isLoggedIn ? 'pixelarticons:user' : 'pixelarticons:login'" class="icon-md lg:hidden" />
+      <template v-if="user">
+        <NuxtLink
+          to="/panel/profile"
+          class="flex items-center gap-2 cursor-pointer font-semibold text-md lg:hidden"
+          aria-label="Profil użytkownika"
+        >
+          <UIcon name="pixelarticons:user" class="icon-md" />
+        </NuxtLink>
 
-        <span class="hidden lg:inline">
-          {{ isLoggedIn ? "Otwórz panel" : "Zaloguj się" }}
-        </span>
+        <UDropdownMenu
+          :items="userMenuItems"
+          :content="{ align: 'end', sideOffset: 8 }"
+          :ui="{ content: 'w-48', item: 'cursor-pointer' }"
+        >
+          <button class="hidden lg:flex items-center gap-2 cursor-pointer font-semibold text-md" aria-label="Menu użytkownika">
+            <UIcon name="pixelarticons:user" class="icon-md" />
+            <span class="hidden lg:inline">{{ user.username }}</span>
+          </button>
+        </UDropdownMenu>
+      </template>
+
+      <NuxtLink v-else to="/login" class="text-md font-semibold flex grow-0" aria-label="Zaloguj się">
+        <UIcon name="pixelarticons:login" class="icon-md lg:hidden" />
+        <span class="hidden lg:inline">Zaloguj się</span>
       </NuxtLink>
     </template>
 

--- a/frontend/app/composables/useSession.ts
+++ b/frontend/app/composables/useSession.ts
@@ -1,0 +1,17 @@
+// Current auth implementation is temporary and missing many features.
+// See: https://github.com/Hack4Krak/Hack4KrakSite/issues/435
+
+export default function useSession() {
+  const { $auth } = useNuxtApp()
+
+  async function logout() {
+    await $auth('/auth/logout', {
+      method: 'POST',
+    })
+
+    await refreshNuxtData()
+    await navigateTo('/login')
+  }
+
+  return { logout }
+}

--- a/frontend/app/pages/panel/profile.vue
+++ b/frontend/app/pages/panel/profile.vue
@@ -1,22 +1,10 @@
 <script setup lang="ts">
-const { $api } = useNuxtApp()
-
 const { data: user } = await useAuth('/account/')
 
 const joinExternalTeamModal = ref(false)
 const updateAccountModal = ref(false)
 const changePasswordModal = ref(false)
 const deleteAccountModal = ref(false)
-
-async function logout() {
-  await $api('/auth/logout', {
-    method: 'POST',
-    credentials: 'include',
-  })
-
-  await refreshNuxtData()
-  await navigateTo('/login')
-}
 </script>
 
 <template>
@@ -56,7 +44,7 @@ async function logout() {
           <UButton icon="mdi:account-remove" variant="ghost" color="neutral" @click="deleteAccountModal = true">
             Usuń konto
           </UButton>
-          <UButton icon="mdi:logout" variant="ghost" color="neutral" @click="logout">
+          <UButton icon="mdi:logout" variant="ghost" color="neutral" @click="useSession().logout">
             Wyloguj się
           </UButton>
         </div>


### PR DESCRIPTION
Logging out was taking me a long time, so I thought about adding a context menu here

Preview:
<img width="302" height="228" alt="image" src="https://github.com/user-attachments/assets/7389adbc-3e4f-480d-8f3e-1280fc2ec816" />

Btw this PR also closes #665 