### PR TITLE
fix(frontend): ensure auth fetch retries after token refresh

### DIFF
--- a/frontend/app/plugins/openFetch.ts
+++ b/frontend/app/plugins/openFetch.ts
@@ -1,3 +1,37 @@
+import type { FetchContext, FetchOptions } from 'ofetch'
+
+type NuxtAppWithContext = Pick<ReturnType<typeof useNuxtApp>, 'runWithContext'>
+type ResponseErrorContext = FetchContext & { response: NonNullable<FetchContext['response']> }
+
+async function handleResponseError(
+  nuxtApp: NuxtAppWithContext,
+  context: ResponseErrorContext,
+  localOptions: FetchOptions,
+) {
+  const hooks = localOptions.onResponseError
+  if (Array.isArray(hooks)) {
+    await Promise.all(hooks.map(hook => hook(context)))
+    return
+  } else if (typeof hooks === 'function') {
+    await hooks(context)
+    return
+  }
+
+  if (Object.hasOwn(localOptions, 'onResponseError')) {
+    return
+  }
+
+  const data = context.response._data
+  context.error = data.error
+
+  const description = `${context.response.status}: ${data.message ?? 'Nieznany błąd'}`
+  nuxtApp.runWithContext(() => useToast().add({
+    title: 'Błąd zapytania',
+    description,
+    color: 'error',
+  }))
+}
+
 export default defineNuxtPlugin((nuxtApp) => {
   const clients = useRuntimeConfig().public.openFetch
   const localFetch = useRequestFetch()
@@ -6,40 +40,39 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   return {
     provide: {
-      api: createOpenFetch(localOptions => ({
+      api: createOpenFetch((localOptions = {}) => ({
         ...clients.api,
         headers,
+        ...localOptions,
         async onResponseError(context) {
           const data = context.response._data
           if (!data.error) {
             return
           }
 
-          const description = `${context.response.status}: ${data.message ?? 'Nieznany błąd'}`
-          nuxtApp.runWithContext(() => useToast().add({ title: 'Błąd zapytania', description, color: 'error' }))
-
-          context.error = data?.error
+          await handleResponseError(nuxtApp, context, localOptions)
         },
-        ...localOptions,
       }), localFetch as typeof $fetch),
-      auth: createOpenFetch(localOptions => ({
+      auth: createOpenFetch((localOptions = {}) => ({
         ...clients.auth,
         retryStatusCodes: [401],
         retry: 1,
         credentials: 'include',
-        ignoreResponseError: true,
         headers,
-        async onResponse(context) {
-          if (context.response?._data.error && context.response?._data.error !== 'Unauthorized') {
-            const hooks = context.options.onResponseError
-            if (Array.isArray(hooks)) {
-              hooks.forEach(hook => hook(context))
-            } else if (typeof hooks === 'function') {
-              hooks(context)
-            }
+        ...localOptions,
+        async onResponseError(context) {
+          const data = context.response._data
+          const status = context.response.status
+          if (!data.error) {
+            return
           }
 
-          if (context.response.status !== 401) {
+          if (data.error !== 'Unauthorized' || status !== 401) {
+            await handleResponseError(nuxtApp, context, localOptions)
+            return
+          }
+
+          if (context.options.retry === 0 || context.options.retry === false) {
             return
           }
 
@@ -48,49 +81,26 @@ export default defineNuxtPlugin((nuxtApp) => {
             baseURL: clients.auth.baseURL,
             headers,
             credentials: 'include',
-            onResponseError() {
-              nuxtApp.runWithContext(() => {
-                if (context.options.redirect !== 'error') {
-                  navigateTo('/login')
-                }
-              })
-            },
+            ignoreResponseError: true,
           })
 
           if (!response.ok) {
+            context.options.retry = 0
             if (context.options.redirect !== 'error') {
               nuxtApp.runWithContext(() => navigateTo('/login'))
             }
             return
           }
 
-          const cookies = (response.headers.get('set-cookie') || '').split(',')
-          context.options.headers.set('cookie', cookies.map(c => c.split(';')[0]).join(';'))
-
           if (import.meta.server) {
-            nuxtApp.ssrContext?.event.node.res.setHeader('Set-Cookie', cookies)
+            const setCookie = response.headers.get('set-cookie')
+            if (setCookie) {
+              const cookies = setCookie.split(',')
+              context.options.headers.set('cookie', cookies.map(c => c.split(';')[0]).join(';'))
+              nuxtApp.ssrContext?.event.node.res.setHeader('Set-Cookie', cookies)
+            }
           }
         },
-        onResponseError(context) {
-          const data = context.response._data
-          const status = context.response.status
-          if (!data.error) {
-            return
-          }
-
-          // We sometimes get Unauthorized, but we handle it and refresh access token
-          if (data.error === 'Unauthorized') {
-            return
-          }
-          nuxtApp.runWithContext(() => useToast().add({
-            title: `Błąd ${status}`,
-            description: data.message ?? 'Nieznany błąd',
-            color: 'error',
-          }))
-
-          context.error = data.error
-        },
-        ...localOptions,
       }), localFetch as typeof $fetch),
     },
   }

--- a/frontend/tests/plugins/openFetch.test.ts
+++ b/frontend/tests/plugins/openFetch.test.ts
@@ -1,0 +1,85 @@
+import { useNuxtApp } from 'nuxt/app'
+import { createFetch } from 'ofetch'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('auth openFetch client', () => {
+  const originalFetch = globalThis.$fetch
+
+  afterEach(() => {
+    globalThis.$fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('refreshes the access token and retries the original request', async () => {
+    const requests: string[] = []
+
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      requests.push(new URL(url).pathname)
+
+      if (url.endsWith('/account/') && requests.filter(request => request === '/account/').length === 1) {
+        return new Response(JSON.stringify({ error: 'Unauthorized', message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+
+      if (url.endsWith('/auth/refresh')) {
+        return new Response(null, {
+          status: 200,
+          headers: { 'set-cookie': 'access_token=fresh; Path=/; HttpOnly' },
+        })
+      }
+
+      if (url.endsWith('/account/')) {
+        return new Response(JSON.stringify({ username: 'RefreshedUser' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    globalThis.$fetch = createFetch({ fetch }) as typeof globalThis.$fetch
+
+    const { $auth } = useNuxtApp() as unknown as {
+      $auth: (url: string, options?: Record<string, unknown>) => Promise<unknown>
+    }
+
+    await expect($auth('/account/', { redirect: 'error', onResponseError: undefined })).resolves.toEqual({ username: 'RefreshedUser' })
+    expect(requests).toEqual(['/account/', '/auth/refresh', '/account/'])
+  })
+
+  it('does not retry the original request when token refresh fails', async () => {
+    const requests: string[] = []
+
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      requests.push(new URL(url).pathname)
+
+      if (url.endsWith('/account/')) {
+        return new Response(JSON.stringify({ error: 'Unauthorized', message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+
+      if (url.endsWith('/auth/refresh')) {
+        return new Response(JSON.stringify({ error: 'Unauthorized', message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    globalThis.$fetch = createFetch({ fetch }) as typeof globalThis.$fetch
+
+    const { $auth } = useNuxtApp() as unknown as {
+      $auth: (url: string, options?: Record<string, unknown>) => Promise<unknown>
+    }
+
+    await expect($auth('/account/', { redirect: 'error' })).rejects.toMatchObject({ status: 401 })
+    expect(requests).toEqual(['/account/', '/auth/refresh'])
+  })
+})


### PR DESCRIPTION
Fixes an issue where requests were not retried after a successful token refresh. Adds tests covering this behavior and refactors the shared logic to ensure `$api` and `$auth` handle it consistently.